### PR TITLE
Fixed unused maxiters option

### DIFF
--- a/RACIPELIB.c
+++ b/RACIPELIB.c
@@ -232,7 +232,7 @@ void check_inputfile (int argc, char **argv, struct topo *topoinfo, struct opts 
     printf("-thrd          : Cutoff for convergence of steady states for numerically solving ODEs (Default 1.0).\n");
     printf("-Toggle_f_p    : Save parameters of each RACIPE model or not (Default 1 (yes)).\n");
     printf("-stepsize      : Stepsize for solving ODEs (Default 0.1).\n");
-    printf("-maxiters      : The maximum number of iterations for solving ODEs at each random initial condition (Default 20).\n");
+    printf("-maxiters      : The maximum number of iterations for solving ODEs at each random initial condition times 1000 (Default 20).\n");
     printf("-Toggle_T_test : Test the threshold assumption or not (Default 1 (yes)).\n");
     printf("-SBML_model    : Output a model in the SBML format. The parameter will be the ID of the model (start from 1) to save (Default 0 (no SBML output)).\n");
     printf("-seed          : random seed (Default 1).\n");
@@ -534,7 +534,7 @@ void initial_simuopts (int argc, char **argv, struct topo *topoinfo, struct opts
         printf("-thrd          : Cutoff for convergence of steady states for numerically solving ODEs (Default 1.0).\n");
         printf("-Toggle_f_p    : Save parameters of each RACIPE model or not (Default 1 (yes)).\n");
         printf("-stepsize      : Stepsize for solving ODEs (Default 0.1).\n");
-        printf("-maxiters      : The maximum number of iterations for solving ODEs at each random initial condition (Default 20).\n");
+        printf("-maxiters      : The maximum number of iterations for solving ODEs at each random initial condition times 1000 (Default 20).\n");
         printf("-Toggle_T_test : Test the threshold assumption or not (Default 1 (yes)).\n");
         printf("-SBML_model    : Output a model in the SBML format. The parameter will be the ID of the model (start from 1) to save (Default 0 (no SBML output)).\n");
         printf("-seed          : random seed (Default 1).\n");
@@ -2189,7 +2189,7 @@ void solve_ODE_euler (int j, struct opts *simu_opts, struct topo *topoinfo, stru
     
   testdelta = sumdelta(y, ytmp, topoinfo->numG);
   
-  while (testdelta != 0 && cnt_loop < 20) { // maximum iteration is 20 times
+  while (testdelta != 0 && cnt_loop < simu_opts->maxiters) {
     t_start = t_stop;
     t_stop  = t_stop + 100;
     
@@ -2257,7 +2257,7 @@ void solve_ODE_rk45 (int j, struct opts *simu_opts, struct topo *topoinfo, struc
     
   testdelta = sumdelta(y, ytmp, topoinfo->numG);
   
-  while (testdelta != 0 && cnt_loop < 20) { // maximum iteration is 20 times
+  while (testdelta != 0 && cnt_loop < simu_opts->maxiters) {
     t_start = t_stop;
     t_stop  = t_stop + 100;
     

--- a/README
+++ b/README
@@ -75,7 +75,7 @@ Use "./RACIPE -h" to find all available options.
 -thrd          : Cutoff for convergence of steady states for numerically solving ODEs (Default 1.0).
 -Toggle_f_p    : Save parameters of each RACIPE model or not (Default 1 (yes)).
 -stepsize      : Stepsize for solving ODEs (Default 0.1).
--maxiters      : The maximum number of iterations for solving ODEs at each random initial condition (Default 20).
+-maxiters      : The maximum number of iterations for solving ODEs at each random initial condition times 1000 (Default 20).
 -Toggle_T_test : Test the threshold assumption or not (Default 1 (yes)).
 -SBML_model    : Output a model in the SBML format. The parameter will be the ID of the model (start from 1) to save (Default 0 (no SBML output)).
 -seed          : random seed (Default 1). 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Use "`./RACIPE -h`" to find all available options.<br />
 **-thrd**          : Cutoff for convergence of steady states for numerically solving ODEs (Default 1.0).<br />
 **-Toggle_f_p**    : Save parameters of each RACIPE model or not (Default 1 (yes)).<br />
 **-stepsize**      : Stepsize for solving ODE (Default 0.1).<br />
-**-maxiters**      : Maximum of Iteration for solving ODE at each RIVs (Default 20).<br />
+**-maxiters**      : Maximum of Iteration for solving ODE at each RIVs times 1000 (Default 20).<br />
 **-Toggle_T_test** : Test threshold assumption or not (Default 1 (yes)).<br />
 **-seed**          : Set up random seed (Default 1). <br />
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;*Attention*: the actual seed used by the package is a function of the starting time and the seed set here. -seed is used for the case you run the package at the same time for the same circuit several times. <br /><br />


### PR DESCRIPTION
The option `maxiters`, stored as `simu_opts->maxiters` was not used after storing it, and the number of times the loop runs was hard coded to be 20. Also changed the option-descriptions to better reflect the meaning of the `maxiters` option, which, if I understand correctly, is the number of times the outer loop runs while the inner loop is fixed to 1000 steps/iterations for each of the outer loop's run.